### PR TITLE
feat(CD): add semantic-release to PyPi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,16 @@ install:
   - pip install pytest pytest-cov
 
 script:
-  - python -m pytest --cov=dragonfly
+  - python -m pytest
+
+jobs:
+  include:
+    - stage: deploy
+      python: "3.6"
+      env: TRAVIS=true
+      if: branch = master
+      script:
+        - git config --global user.name "ladybugbot"
+        - git config --global user.email "release@ladybug.tools"
+        - pip install python-semantic-release
+        - semantic-release publish

--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -1,4 +1,6 @@
 import sys
 
+__version__ = '0.2.0'
+
 # This is a variable to check if the library is a [+] library.
 setattr(sys.modules[__name__], 'isplus', False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+lbt-ladybug==0.*
+uwg==5.*

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,28 @@
+import re
 import setuptools
+import sys
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+with open('dragonfly/__init__.py', 'r') as fd:
+    version = re.search(
+        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+        fd.read(),
+        re.MULTILINE
+    ).group(1)
+
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+try:
+    from semantic_release import setup_hook
+    setup_hook(sys.argv)
+except ImportError:
+    pass
+
 setuptools.setup(
-    name="dragonfly",
-    version="0.2.0",
+    name="lbt-dragonfly",
+    version=version,
     author="ladybug-tools",
     description="Dragonfly is a python library for urban climate + urban energy modeling.",
     long_description=long_description,
@@ -13,11 +30,10 @@ setuptools.setup(
     url="https://github.com/ladybug-tools/dragonfly",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    dependency_links=[
-        "https://github.com/ladybug-tools/uwg/archive/master.zip"
-    ],
+    install_requires=requirements,
     classifiers=[
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 2.7",,
+        "Programming Language :: Python :: 3.6"
         "Operating System :: OS Independent",
     ],
 )


### PR DESCRIPTION
The commits in this PR will enable semantic release to a package called `lbt-dragonfly` (which does not exist yet). There are a few more steps to carry out in order to make this possible however:

1. . Add Travis environment variables to the build [like this](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings)
  * GH_TOKEN: a github token generated by the owner of the ladybug-tools repo (this will allow travis to commit and tag new releases to the repo). **Make it secret**
  *  PYPI_USERNAME: the PyPi username who will be in charge of releasing (other repos use `ladybug-tools`
  * PYPI_PASSWORD: the PyPi user's password. **Make it secret**

2. Merge this PR

3. ???

4. Bath in the joys of effortless automation.

PS: note that unlike ladybug, honeybee and uwg I have changed the .travis.yml to build in stages. Currently travis tests and deploys python 2 and then tests/deploys python 3. What the file for dragonfly should do is test python 2, test python3 and then if both pass and the branch is master it will attempt a deployment.